### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Create dependabot.yml, maintain its updates to the default weekly interval schedule and assign to package-ecosystem the value of github-actions.

It may be altered to npm in the future, but even transpiling React, Next.js and Frame Motion original project's package dependencies to Angular and its TypeScript-based code syntax, regardless the expected TypeScript JIT compiling into vanilla JavaScript.